### PR TITLE
Add unicode support

### DIFF
--- a/abp/filters/parser.py
+++ b/abp/filters/parser.py
@@ -276,7 +276,7 @@ def parse_line(line_text):
     ParseError
         ParseError: If the line can't be parsed.
     """
-    content = line_text.strip()
+    content = line_text.strip().decode('utf-8')
 
     if content == '':
         line = EmptyLine()


### PR DESCRIPTION
Try to use python-abp API for ruadlist:
```
from abp.filters import parse_filterlist

with open('ruadlist+easylist.txt') as filterlist:
    for line in parse_filterlist(filterlist):
        print(line)
```

Get error:
```
Traceback (most recent call last):
  File "/Users/ddemidov/workspace/yandex/python-abp/test_parser.py", line 4, in <module>
    for line in parse_filterlist(filterlist):
  File "/Users/ddemidov/workspace/yandex/python-abp/abp/filters/parser.py", line 318, in parse_filterlist
    yield parse_line(line)
  File "/Users/ddemidov/workspace/yandex/python-abp/abp/filters/parser.py", line 283, in parse_line
    elif content.startswith('!'):
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 2: ordinal not in range(128)
```
Try to fix that