### PR TITLE
partner Metadata

### DIFF
--- a/abp/filters/parser.py
+++ b/abp/filters/parser.py
@@ -304,6 +304,9 @@ def parse_line(line, position='body'):
             key, value = match.groups()
             if position != 'body' or key.lower() == 'checksum':
                 return Metadata(key, value)
+        if stripped[1:].startswith(':'):
+            meta = stripped[2:].split("=")
+            return Metadata(meta[0],meta[1])
         return Comment(stripped[1:].lstrip())
 
     if stripped.startswith('%include') and stripped.endswith('%'):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -146,6 +146,11 @@ def test_parse_comment():
     assert line.type == 'comment'
     assert line.text == 'Block foo'
 
+def test_parse_comment_meta():
+    line = parse_line('!:test_key=Some value')
+    assert line.type == 'metadata'
+    assert line.key == 'test_key'
+    assert line.value == 'Some value'
 
 def test_parse_instruction():
     line = parse_line('%include foo:bar/baz.txt%')


### PR DESCRIPTION
Comments on the exception list have what we call "partner metadata", they look like this

!:partner_token=Oath
!:partner_id=89957ff1e879eb7f
!:type=partner
!:forum=https://adblockplus.org/forum/viewtopic.php?f=12&t=24361
! Yahoo display ads

This change returns a metadata object for all of those key=value pairs, returns Comment object for the regular comments, like so: 

Metadata(key='partner_token', value='Oath')
Metadata(key='partner_id', value='89957ff1e879eb7f')
Metadata(key='partner', value='partner')
Metadata(key='forum',value='https://adblockplus.org/forum/viewtopic.php?f=12&t=24361')
Comment(text='Yahoo display ads')

