### PR TITLE
Fixed parsing of element hiding filters when domains include wildcards

### DIFF
--- a/abp/filters/parser.py
+++ b/abp/filters/parser.py
@@ -192,7 +192,7 @@ Include = _line_type('Include', 'target', '%include {0.target}%')
 METADATA_REGEXP = re.compile(r'\s*!\s*([\w\-\s]*\w)\s*:\s*(.*)')
 INCLUDE_REGEXP = re.compile(r'%include\s+(.+)%')
 HEADER_REGEXP = re.compile(r'\[(Adblock(?:\s*Plus\s*[\d\.]+?)?)\]', flags=re.I)
-HIDING_FILTER_REGEXP = re.compile(r'^([^/*|@"!]*?)#([@?$])?#(.+)$')
+HIDING_FILTER_REGEXP = re.compile(r'^([^/|@"!]*?)#([@?$])?#(.+)$')
 FILTER_OPTIONS_REGEXP = re.compile(
     r'\$(~?[\w-]+(?:=[^,]+)?(?:,~?[\w-]+(?:=[^,]+)?)*)$',
 )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -112,6 +112,21 @@ def test_parse_empty():
     'foo,~bar##ddd': {
         'options': [(FilterOption.DOMAIN, [('foo', True), ('bar', False)])],
     },
+    'foo.*##ddd': {
+        'selector': {'type': SelType.CSS, 'value': 'ddd'},
+        'action': FilterAction.HIDE,
+        'options': [(FilterOption.DOMAIN, [('foo.*', True)])],
+    },
+    '1.2.3.4,example.*##.some-css-class': {
+        'selector': {'type': SelType.CSS, 'value': '.some-css-class'},
+        'action': FilterAction.HIDE,
+        'options': [(FilterOption.DOMAIN, [('1.2.3.4', True), ('example.*', True)])],
+    },
+    'foo.*,~bar#@#body > div:first-child': {
+        'selector': {'type': SelType.CSS, 'value': 'body > div:first-child'},
+        'action': FilterAction.SHOW,
+        'options': [(FilterOption.DOMAIN, [('foo.*', True), ('bar', False)])],
+    },
     # Element hiding emulation filters (extended CSS).
     'foo,~bar#?#:-abp-properties(abc)': {
         'selector': {'type': SelType.XCSS, 'value': ':-abp-properties(abc)'},


### PR DESCRIPTION
The current version of `python-abp` wrongly parses as network block filters (`FilterAction.BLOCK`) some element hiding filters whose target domains include some wildcard.

An example of such filter is `185.224.130.67,dutafilm.*##.swal-overlay`, which can be found in [AdGuard Base filter list](https://filters.adtidy.org/extension/chromium/filters/2.txt).

The issue seems to be caused by the following regular expression:
https://github.com/adblockplus/python-abp/blob/450cc854e2556674e756f7723e67972ac12b8a34/abp/filters/parser.py#L195

It doesn't allow the usage of `*` in the set of target domains for element hiding filters.

This PR adds some test cases for this scenario and removes the `*` from the regular expression's exluded chars.